### PR TITLE
Start support for GitHub tables via GraphQL API `github_stargazers`, `github_starred_repos`, `github_stargazers_count`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,9 +11,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var format string      // output format flag
-var presetQuery string // named / preset query flag
-var repo string        // path to repo on disk
+var format string                           // output format flag
+var presetQuery string                      // named / preset query flag
+var repo string                             // path to repo on disk
+var githubToken = os.Getenv("GITHUB_TOKEN") // GitHub auth token for GitHub tables
 
 func init() {
 	// local (root command only) flags

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -16,6 +16,7 @@ func registerExt() {
 			tables.WithExtraFunctions(),
 			tables.WithRepoLocator(locator.CachedLocator(locator.MultiLocator())),
 			tables.WithContextValue("defaultRepoPath", repo),
+			tables.WithContextValue("githubToken", githubToken),
 		),
 	)
 }

--- a/go.mod
+++ b/go.mod
@@ -29,8 +29,8 @@ require (
 	go.riyazali.net/sqlite v0.0.0-20210707161919-414349b4032a
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
 	golang.org/x/net v0.0.0-20210716203947-853a461950ff // indirect
-	golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914 // indirect
+	golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
-	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 )

--- a/go.mod
+++ b/go.mod
@@ -22,11 +22,15 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.8
 	github.com/pkg/errors v0.9.1
 	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/shurcooL/githubv4 v0.0.0-20201206200315-234843c633fa
+	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a // indirect
 	github.com/spf13/cobra v1.2.1
 	go.mongodb.org/mongo-driver v1.6.0 // indirect
 	go.riyazali.net/sqlite v0.0.0-20210707161919-414349b4032a
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
 	golang.org/x/net v0.0.0-20210716203947-853a461950ff // indirect
+	golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914 // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,7 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
+github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -332,6 +333,10 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/shurcooL/githubv4 v0.0.0-20201206200315-234843c633fa h1:jozR3igKlnYCj9IVHOVump59bp07oIRoLQ/CcjMYIUA=
+github.com/shurcooL/githubv4 v0.0.0-20201206200315-234843c633fa/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
+github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a h1:KikTa6HtAK8cS1qjvUvvq4QO21QnwC+EfvB+OAuZ/ZU=
+github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
@@ -492,6 +497,8 @@ golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914 h1:3B43BWw0xEBsLZ/NO1VALz6fppU3481pik+2Ksv45z8=
+golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -576,6 +583,8 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac h1:7zkz7BUtwNFFqcowJ+RIgu2MaV/MapERkDIy+mwPyjs=
+golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
@@ -664,6 +673,7 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -737,6 +747,7 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/shared.go
+++ b/shared.go
@@ -5,6 +5,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/askgitdev/askgit/pkg/locator"
 	"github.com/askgitdev/askgit/tables"
 	"go.riyazali.net/sqlite"
@@ -14,6 +16,7 @@ func init() {
 	sqlite.Register(tables.RegisterFn(
 		tables.WithExtraFunctions(),
 		tables.WithRepoLocator(locator.CachedLocator(locator.MultiLocator())),
+		tables.WithContextValue("githubToken", os.Getenv("GITHUB_TOKEN")),
 	))
 }
 

--- a/tables/internal/github/stargazers.go
+++ b/tables/internal/github/stargazers.go
@@ -1,0 +1,247 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/augmentable-dev/vtab"
+	"github.com/shurcooL/githubv4"
+	"go.riyazali.net/sqlite"
+	"golang.org/x/oauth2"
+	"golang.org/x/time/rate"
+)
+
+type stargazer struct {
+	Login           string
+	Email           string
+	Name            string
+	Bio             string
+	Company         string
+	IsHireable      bool
+	AvatarUrl       string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+	TwitterUsername string
+	WebsiteUrl      string
+	Location        string
+}
+
+type fetchStarsOptions struct {
+	Client      *githubv4.Client
+	Owner       string
+	Name        string
+	PerPage     int
+	StartCursor *githubv4.String
+	StarOrder   *githubv4.StarOrder
+}
+
+type fetchStarsResults struct {
+	Edges       []edge //why not []*Edge
+	HasNextPage bool
+	EndCursor   *githubv4.String
+}
+
+type edge struct { //change to a more informative name.
+	StarredAt string    //StarredAt insists on being a string whereas createdAt and updatedAt are time.Time.
+	Node      stargazer //change to a more informative name
+}
+
+func fetchStars(ctx context.Context, input *fetchStarsOptions) (*fetchStarsResults, error) {
+	var starsQuery struct {
+		Repository struct {
+			Owner struct {
+				Login string
+			}
+			Name       string
+			Stargazers struct {
+				Edges    []edge
+				PageInfo struct {
+					EndCursor   githubv4.String
+					HasNextPage bool
+				}
+			} `graphql:"stargazers(first: $perpage, after: $stargazersCursor, orderBy: $starorder)"`
+		} `graphql:"repository(owner: $owner, name: $name)"`
+	}
+	variables := map[string]interface{}{
+		"owner":            githubv4.String(input.Owner),
+		"name":             githubv4.String(input.Name),
+		"perpage":          githubv4.Int(input.PerPage),
+		"stargazersCursor": (*githubv4.String)(input.StartCursor),
+		"starorder":        input.StarOrder,
+	}
+
+	err := input.Client.Query(ctx, &starsQuery, variables)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &fetchStarsResults{
+		starsQuery.Repository.Stargazers.Edges,
+		starsQuery.Repository.Stargazers.PageInfo.HasNextPage,
+		&starsQuery.Repository.Stargazers.PageInfo.EndCursor,
+	}, nil
+}
+
+type iterStargazers struct {
+	fullNameOrOwner string
+	name            string
+	client          *githubv4.Client
+	current         int
+	results         *fetchStarsResults
+	rateLimiter     *rate.Limiter
+	starOrder       *githubv4.StarOrder
+}
+
+// repoOwnerAndName returns the "owner" and "name" (respective return values) or an error
+// given the inputs to the iterator. This allows for both `SELECT * FROM github_stargazers('askgitdev/starq')`
+// and `SELECT * FROM github_stargazers('askgitdev', 'starq')
+func (i *iterStargazers) repoOwnerAndName() (string, string, error) {
+	if i.name == "" {
+
+		split_string := strings.Split(i.fullNameOrOwner, "/")
+		if len(split_string) != 2 {
+			return "", "", errors.New("invalid repo name, must be of format owner/name")
+		}
+		return split_string[0], split_string[1], nil
+	} else {
+		return i.fullNameOrOwner, i.name, nil
+	}
+}
+
+func (i *iterStargazers) Column(ctx *sqlite.Context, c int) error {
+	switch c {
+	case 0:
+		ctx.ResultText(i.fullNameOrOwner)
+	case 1:
+		ctx.ResultText(i.name)
+	case 2:
+		ctx.ResultText(i.results.Edges[i.current].Node.Login)
+	case 3:
+		ctx.ResultText(i.results.Edges[i.current].Node.Email)
+	case 4:
+		ctx.ResultText(i.results.Edges[i.current].Node.Name)
+	case 5:
+		ctx.ResultText(i.results.Edges[i.current].Node.Bio)
+	case 6:
+		ctx.ResultText(i.results.Edges[i.current].Node.Company)
+	case 7:
+		ctx.ResultText(i.results.Edges[i.current].Node.AvatarUrl)
+	case 8:
+		t := i.results.Edges[i.current].Node.CreatedAt
+		if t.IsZero() {
+			ctx.ResultText(" ")
+		} else {
+			ctx.ResultText(t.Format(time.RFC3339Nano))
+		}
+	case 9:
+		t := i.results.Edges[i.current].Node.UpdatedAt
+		if t.IsZero() {
+			ctx.ResultText(" ")
+		} else {
+			ctx.ResultText(t.Format(time.RFC3339Nano))
+		}
+	case 10:
+		ctx.ResultText(i.results.Edges[i.current].Node.TwitterUsername)
+	case 11:
+		ctx.ResultText(i.results.Edges[i.current].Node.WebsiteUrl)
+	case 12:
+		ctx.ResultText(i.results.Edges[i.current].Node.Location)
+	case 13:
+		ctx.ResultText(i.results.Edges[i.current].StarredAt)
+	}
+	return nil
+}
+
+func (i *iterStargazers) Next() (vtab.Row, error) {
+	i.current += 1
+
+	if i.results == nil || i.current >= len(i.results.Edges) {
+		if i.results == nil || i.results.HasNextPage {
+			err := i.rateLimiter.Wait(context.Background())
+			if err != nil {
+				return nil, err
+			}
+
+			owner, name, err := i.repoOwnerAndName()
+			if err != nil {
+				return nil, err
+			}
+
+			var cursor *githubv4.String
+			if i.results != nil {
+				cursor = i.results.EndCursor
+			}
+
+			results, err := fetchStars(context.Background(), &fetchStarsOptions{i.client, owner, name, 100, cursor, i.starOrder})
+			if err != nil {
+				return nil, err
+			}
+
+			i.results = results
+			i.current = 0
+
+		} else {
+			return nil, io.EOF
+		}
+	}
+
+	return i, nil
+}
+
+var cols_stargazers = []vtab.Column{
+	{Name: "owner", Type: sqlite.SQLITE_TEXT, NotNull: true, Hidden: true, Filters: []*vtab.ColumnFilter{{Op: sqlite.INDEX_CONSTRAINT_EQ, Required: true, OmitCheck: true}}, OrderBy: vtab.NONE},
+	{Name: "reponame", Type: sqlite.SQLITE_TEXT, NotNull: true, Hidden: true, Filters: []*vtab.ColumnFilter{{Op: sqlite.INDEX_CONSTRAINT_EQ}}, OrderBy: vtab.NONE},
+	{Name: "login", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "email", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "name", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "bio", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "company", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "avatar_url", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "created_at", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "updated_at", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "twitter", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "website", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "location", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "starred_at", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.ASC | vtab.DESC},
+}
+
+func NewStargazersModule(githubToken string, rateLimiter *rate.Limiter) sqlite.Module {
+	httpClient := oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: githubToken},
+	))
+	client := githubv4.NewClient(httpClient)
+
+	return vtab.NewTableFunc("github_stargazers", cols_stargazers, func(constraints []*vtab.Constraint, orders []*sqlite.OrderBy) (vtab.Iterator, error) {
+		var fullNameOrOwner, name string
+		for _, constraint := range constraints {
+			if constraint.Op == sqlite.INDEX_CONSTRAINT_EQ {
+				switch constraint.ColIndex {
+				case 0:
+					fullNameOrOwner = constraint.Value.Text()
+				case 1:
+					name = constraint.Value.Text()
+				}
+			}
+		}
+
+		starOrder := &githubv4.StarOrder{
+			Field:     githubv4.StarOrderFieldStarredAt,
+			Direction: githubv4.OrderDirectionDesc,
+		}
+
+		for _, order := range orders { //adding this for loop for scalability. might need to order the data by more columns in the future.
+			switch order.ColumnIndex {
+			case 13:
+				if !order.Desc {
+					starOrder.Direction = githubv4.OrderDirectionAsc
+				}
+			}
+		}
+
+		return &iterStargazers{fullNameOrOwner, name, client, -1, nil, rateLimiter, starOrder}, nil
+	})
+}

--- a/tables/internal/github/stargazers_count.go
+++ b/tables/internal/github/stargazers_count.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/time/rate"
 )
 
-type starCount struct { //change to starCount
+type starCount struct {
 	rateLimiter *rate.Limiter
 	client      *githubv4.Client
 }

--- a/tables/internal/github/stargazers_count.go
+++ b/tables/internal/github/stargazers_count.go
@@ -1,0 +1,70 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/shurcooL/githubv4"
+	"go.riyazali.net/sqlite"
+	"golang.org/x/oauth2"
+	"golang.org/x/time/rate"
+)
+
+type starCount struct { //change to starCount
+	rateLimiter *rate.Limiter
+	client      *githubv4.Client
+}
+
+func (s *starCount) Args() int           { return -1 }
+func (s *starCount) Deterministic() bool { return false }
+func (s *starCount) Apply(ctx *sqlite.Context, values ...sqlite.Value) {
+	err := s.rateLimiter.Wait(context.Background())
+	if err != nil {
+		ctx.ResultError(err)
+		return
+	}
+
+	var starsCountQuery struct {
+		Repository struct {
+			StargazerCount int
+		} `graphql:"repository(owner: $owner, name: $name)"`
+	}
+
+	var owner, name string
+	switch len(values) {
+	case 0:
+		ctx.ResultError(errors.New("need to supply a repo"))
+		return
+	case 1:
+		split_string := strings.Split(values[0].Text(), "/")
+		if len(split_string) != 2 {
+			ctx.ResultError(errors.New("invalid repo name, must be of format owner/name"))
+			return
+		}
+		owner = split_string[0]
+		name = split_string[1]
+	default:
+		owner = values[0].Text()
+		name = values[1].Text()
+	}
+
+	variables := map[string]interface{}{
+		"owner": githubv4.String(owner),
+		"name":  githubv4.String(name),
+	}
+	err = s.client.Query(context.Background(), &starsCountQuery, variables)
+	if err != nil {
+		ctx.ResultError(err)
+		return
+	}
+	ctx.ResultInt(starsCountQuery.Repository.StargazerCount)
+}
+
+func NewStarredReposFunc(githubToken string, rateLimiter *rate.Limiter) sqlite.Function {
+	httpClient := oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: githubToken},
+	))
+	client := githubv4.NewClient(httpClient)
+	return &starCount{rateLimiter: rateLimiter, client: client}
+}

--- a/tables/internal/github/starred_repos.go
+++ b/tables/internal/github/starred_repos.go
@@ -1,0 +1,189 @@
+package github
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/augmentable-dev/vtab"
+	"github.com/shurcooL/githubv4"
+	"go.riyazali.net/sqlite"
+	"golang.org/x/oauth2"
+	"golang.org/x/time/rate"
+)
+
+type fetchReposOptions struct {
+	Client      *githubv4.Client
+	Login       string
+	PerPage     int
+	StartCursor *githubv4.String
+}
+
+type fetchReposResults struct {
+	StarredRepos []*starredRepo
+	HasNextPage  bool
+	EndCursor    *githubv4.String
+}
+
+//TODO: Add more fields
+//TODO: Resolve error from StargazerCount and ProjectsUrl
+
+type starredRepo struct {
+	Name           string
+	Url            string
+	Description    string
+	CreatedAt      time.Time
+	PushedAt       time.Time
+	UpdatedAt      time.Time
+	StargazerCount int
+	NameWithOwner  string
+	// ProjectsUrl    *githubv4.URI
+}
+
+func fetchRepos(ctx context.Context, input *fetchReposOptions) (*fetchReposResults, error) {
+	var reposQuery struct {
+		User struct {
+			Login               string
+			StarredRepositories struct {
+				Nodes    []*starredRepo
+				PageInfo struct {
+					EndCursor   githubv4.String
+					HasNextPage bool
+				}
+			} `graphql:"starredRepositories(first: $perpage, after: $startcursor)"`
+		} `graphql:"user(login: $login)"`
+	}
+
+	variables := map[string]interface{}{
+		"perpage":     githubv4.Int(input.PerPage),
+		"startcursor": input.StartCursor,
+		"login":       githubv4.String(input.Login),
+	}
+
+	err := input.Client.Query(ctx, &reposQuery, variables)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &fetchReposResults{
+		reposQuery.User.StarredRepositories.Nodes,
+		reposQuery.User.StarredRepositories.PageInfo.HasNextPage,
+		&reposQuery.User.StarredRepositories.PageInfo.EndCursor,
+	}, nil
+
+}
+
+type iterStarredRepos struct {
+	login       string
+	client      *githubv4.Client
+	current     int
+	results     *fetchReposResults
+	rateLimiter *rate.Limiter
+}
+
+func (i *iterStarredRepos) Column(ctx *sqlite.Context, c int) error {
+
+	switch c {
+	case 0:
+		ctx.ResultText(i.login)
+	case 1:
+		ctx.ResultText(i.results.StarredRepos[i.current].Name)
+	case 2:
+		ctx.ResultText(i.results.StarredRepos[i.current].Url)
+	case 3:
+		ctx.ResultText(i.results.StarredRepos[i.current].Description)
+	case 4:
+		t := i.results.StarredRepos[i.current].CreatedAt
+		if t.IsZero() {
+			ctx.ResultText(" ")
+		} else {
+			ctx.ResultText(t.Format(time.RFC3339Nano))
+		}
+	case 5:
+		t := i.results.StarredRepos[i.current].PushedAt
+		if t.IsZero() {
+			ctx.ResultText(" ")
+		} else {
+			ctx.ResultText(t.Format(time.RFC3339Nano))
+		}
+	case 6:
+		t := i.results.StarredRepos[i.current].UpdatedAt
+		if t.IsZero() {
+			ctx.ResultText(" ")
+		} else {
+			ctx.ResultText(t.Format(time.RFC3339Nano))
+		}
+	case 7:
+		ctx.ResultInt(i.results.StarredRepos[i.current].StargazerCount)
+	case 8:
+		ctx.ResultText(i.results.StarredRepos[i.current].NameWithOwner)
+		// 	// case 7:
+		// 	return i.results.StarredRepos[i.current].ProjectsUrl, nil
+	}
+	return nil
+}
+
+func (i *iterStarredRepos) Next() (vtab.Row, error) {
+	i.current += 1
+
+	if i.results == nil || i.current >= len(i.results.StarredRepos) {
+		if i.results == nil || i.results.HasNextPage {
+			err := i.rateLimiter.Wait(context.Background())
+			if err != nil {
+				return nil, err
+			}
+
+			var cursor *githubv4.String
+			if i.results != nil {
+				cursor = i.results.EndCursor
+			}
+			results, err := fetchRepos(context.Background(), &fetchReposOptions{i.client, i.login, 100, cursor})
+			if err != nil {
+				return nil, err
+			}
+
+			i.results = results
+			i.current = 0
+
+		} else {
+			return nil, io.EOF
+		}
+	}
+
+	return i, nil
+}
+
+var cols_repos = []vtab.Column{
+	{Name: "login", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: true, Filters: []*vtab.ColumnFilter{{Op: sqlite.INDEX_CONSTRAINT_EQ, Required: true, OmitCheck: true}}, OrderBy: vtab.NONE},
+	{Name: "name", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "url", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "description", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "created_at", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "pushed_at", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "updated_at", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "stargazer_count", Type: sqlite.SQLITE_INTEGER, NotNull: true, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	{Name: "name_with_owner", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+	//{Name: "projects_url", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
+}
+
+func NewStarredReposModule(githubToken string, rateLimiter *rate.Limiter) sqlite.Module {
+	httpClient := oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: githubToken},
+	))
+	client := githubv4.NewClient(httpClient)
+
+	return vtab.NewTableFunc("github_starred_repos", cols_repos, func(constraints []*vtab.Constraint, order []*sqlite.OrderBy) (vtab.Iterator, error) {
+		var login string
+		for _, constraint := range constraints {
+			if constraint.Op == sqlite.INDEX_CONSTRAINT_EQ {
+				switch constraint.ColIndex {
+				case 0:
+					login = constraint.Value.Text()
+				}
+			}
+		}
+
+		return &iterStarredRepos{login, client, -1, nil, rateLimiter}, nil
+	})
+}

--- a/tables/internal/github/starred_repos.go
+++ b/tables/internal/github/starred_repos.go
@@ -154,7 +154,7 @@ func (i *iterStarredRepos) Next() (vtab.Row, error) {
 	return i, nil
 }
 
-var cols_repos = []vtab.Column{
+var starredReposCols = []vtab.Column{
 	{Name: "login", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: true, Filters: []*vtab.ColumnFilter{{Op: sqlite.INDEX_CONSTRAINT_EQ, Required: true, OmitCheck: true}}, OrderBy: vtab.NONE},
 	{Name: "name", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
 	{Name: "url", Type: sqlite.SQLITE_TEXT, NotNull: false, Hidden: false, Filters: nil, OrderBy: vtab.NONE},
@@ -173,7 +173,7 @@ func NewStarredReposModule(githubToken string, rateLimiter *rate.Limiter) sqlite
 	))
 	client := githubv4.NewClient(httpClient)
 
-	return vtab.NewTableFunc("github_starred_repos", cols_repos, func(constraints []*vtab.Constraint, order []*sqlite.OrderBy) (vtab.Iterator, error) {
+	return vtab.NewTableFunc("github_starred_repos", starredReposCols, func(constraints []*vtab.Constraint, order []*sqlite.OrderBy) (vtab.Iterator, error) {
 		var login string
 		for _, constraint := range constraints {
 			if constraint.Op == sqlite.INDEX_CONSTRAINT_EQ {

--- a/tables/internal/github/utils.go
+++ b/tables/internal/github/utils.go
@@ -1,0 +1,27 @@
+package github
+
+import (
+	"strconv"
+
+	"github.com/askgitdev/askgit/tables/services"
+)
+
+// GetGitHubTokenFromCtx looks up the githubToken key in the supplied context and returns it if set
+func GetGitHubTokenFromCtx(ctx services.Context) string {
+	return ctx["githubToken"]
+}
+
+// GetGithubReqPerSecondFromCtx looks up the githubReqPerSec key in the supplied context and returns it if set,
+// otherwise it returns a default of 1
+func GetGithubReqPerSecondFromCtx(ctx services.Context) int {
+	defaultValue := 1
+	if githubReqPerSec, ok := ctx["githubReqPerSec"]; ok && githubReqPerSec != "" {
+		if i, err := strconv.Atoi(githubReqPerSec); err != nil {
+			return i
+		} else {
+			return defaultValue
+		}
+	} else {
+		return defaultValue
+	}
+}


### PR DESCRIPTION
My renamed names are just place holders. We can think of better ones. 