### PR TITLE
GitHub action to push macos and linux binaries on new `v*` releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    name: Publish for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset_name: askgit-linux-amd64
+          # - os: windows-latest
+          #   asset_name: askgit-windows-amd64
+          - os: macos-latest
+            asset_name: askgit-macos-amd64
+
+    steps:
+    - name: Set up Go 1.15
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.15.5
+      id: go
+
+    - name: Check out source
+      uses: actions/checkout@v1
+
+    - name: Install libgit2
+      run: sudo ./scripts/install_libgit2.sh
+
+    - name: Build
+      run: make
+
+    - name: Compress
+      run: tar -czvf askgit.tar.gz -C .build/ .
+
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: askgit.tar.gz
+        asset_name: ${{ matrix.asset_name }}.tar.gz
+        tag: ${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: tests
+name: Tests
 on: [push, pull_request]
 jobs:
   build:


### PR DESCRIPTION
This should begin to address what's been requested in #138 (thanks @wi1dcard for bringing it up) by building binaries for Mac and Linux in a GitHub action that runs when a release tag (`v*`) is pushed. Eventually, we can test releases for windows as well.

It may be worth adding an installation script somewhere at some point, to handle downloading the latest release and dropping it somewhere in a user's path, but this should be a good enough start to allow users to get a prebuilt binary (statically linked to libgit2) vs requiring them to build themselves.

Closes #138 