### PR TITLE
implement an SSH repo locator

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -17,7 +17,7 @@ func registerExt() {
 	sqlite.Register(
 		extensions.RegisterFn(
 			options.WithExtraFunctions(),
-			options.WithRepoLocator(locator.CachedLocator(locator.MultiLocator())),
+			options.WithRepoLocator(locator.CachedLocator(locator.LoggingLocator(&logger, locator.MultiLocator()))),
 			options.WithContextValue("defaultRepoPath", repo),
 			options.WithGitHub(),
 			options.WithContextValue("githubToken", githubToken),

--- a/pkg/locator/locator.go
+++ b/pkg/locator/locator.go
@@ -19,8 +19,10 @@ import (
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/cache"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/go-git/go-git/v5/storage/filesystem"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 )
 
 // DiskLocator is a repo locator implementation that opens on-disk repository at the specified path.
@@ -72,11 +74,35 @@ func HttpLocator() services.RepoLocator {
 	})
 }
 
+// SSHLocator returns a repo locator capable of cloning remote
+// ssh repositories on-demand into temporary storage. It is recommended
+// that you club it with something like CachedLocator to improve performance
+// and remove the need to clone a single repository multiple times.
+func SSHLocator() services.RepoLocator {
+	return options.RepoLocatorFn(func(ctx context.Context, path string) (*git.Repository, error) {
+		path = strings.TrimPrefix(path, "ssh://")
+
+		var dir string
+		var err error
+		if dir, err = ioutil.TempDir(os.TempDir(), "askgit"); err != nil {
+			return nil, errors.Wrap(err, "failed to create a temporary directory")
+		}
+
+		var storer = filesystem.NewStorage(osfs.New(dir), cache.NewObjectLRUDefault())
+		var auth ssh.AuthMethod
+		if auth, err = ssh.DefaultAuthBuilder("git"); err != nil {
+			return nil, errors.Wrap(err, "failed to create an SSH authentication method")
+		}
+		return git.CloneContext(ctx, storer, storer.Filesystem(), &git.CloneOptions{URL: path, NoCheckout: true, Auth: auth})
+	})
+}
+
 // MultiLocator returns a locator service that work with multiple git protocols
 // and is able to pick the correct underlying locator based on path provided.
 func MultiLocator() services.RepoLocator {
 	var locators = map[string]func() services.RepoLocator{
 		"http": HttpLocator,
+		"ssh":  SSHLocator,
 		"file": DiskLocator,
 	}
 
@@ -85,6 +111,17 @@ func MultiLocator() services.RepoLocator {
 		if strings.HasPrefix(path, "http") || strings.HasPrefix(path, "https") {
 			fn = locators["http"]
 		}
+		if strings.HasPrefix(path, "ssh") {
+			fn = locators["ssh"]
+		}
 		return fn().Open(ctx, path)
+	})
+}
+
+// LoggingLocator returns a locator that logs
+func LoggingLocator(logger *zerolog.Logger, rl services.RepoLocator) services.RepoLocator {
+	return options.RepoLocatorFn(func(ctx context.Context, path string) (*git.Repository, error) {
+		logger.Info().Str("path", path).Msgf("opening repo")
+		return rl.Open(ctx, path)
 	})
 }


### PR DESCRIPTION
Simple for now, detects if a repo path starts with `ssh://` (and then strips it out) and uses the go-git ssh auth method to clone to a temporary directory