### PR TITLE
Fix: docs: Add a way to show tables to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,32 @@ See `-h` for all the options.
 
 ### Tables and Functions
 
+To see what tables exist using the CLI, you can run:
+
+```sql
+SELECT name FROM sqlite_master WHERE type IN ('table','view');
+```
+
+to see an output like:
+
+```
++----------+
+| NAME     |
++----------+
+| commits  |
++----------+
+| branches |
++----------+
+| blame    |
++----------+
+| files    |
++----------+
+| stats    |
++----------+
+| tags     |
++----------+
+```
+
 To retrieve a table schema using the CLI, you can run:
 
 ```sql


### PR DESCRIPTION
In #168 @ichengchao requests both `show tables` and `desc table_name`.
This adds documentation to `README.md` to `show tables`.

Bug: #168